### PR TITLE
Bug fix

### DIFF
--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -42,7 +42,7 @@ def query_viewer_db(
         key_cols: Optional[List[str]] = None
 ):
     try:
-        data_dir = user_data_dir(APP_NAME, APP_AUTHOR)
+        data_dir = user_data_dir(APP_NAME, APP_AUTHOR, ensure_exists=True)
         conn = ribbitxdb.connect(data_dir + "/viewer.rbx")
         # regular query
         if isinstance(query, str):


### PR DESCRIPTION
On machines where RibbitXDB Viewer did not exist on the data directory, it failed to launch. This was due to a missing parameter `ensure_exists`. After making it true, it should work